### PR TITLE
Missing dependency electron in package.json #12

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "conf": "^1.3.1",
     "electron-window-state": "^4.1.1",
+    "electron": "^1.8.1",
     "hexy": "^0.2.10",
     "node-forge": "^0.7.1",
     "ws": "^3.3.2",


### PR DESCRIPTION
#12

seems `electron` is included in `devDependency` though, but not in the `dependency` list.